### PR TITLE
fix(docs): update file path

### DIFF
--- a/website/docs/azure-landing-zones/landingzones/platform/single reuse/intro.md
+++ b/website/docs/azure-landing-zones/landingzones/platform/single reuse/intro.md
@@ -232,7 +232,7 @@ skipping: [localhost]
 
 ## Deploy launchpad (level0)
 
-Go to the /tf/caf/configuration/contoso/platform/level0/launchpad/readme.md
+Go to `/tf/caf/configuration/level0/launchpad/readme.md`
 
 ![](../level0-launchpad-readme.png)
 


### PR DESCRIPTION
While doing a single subscription deployment, I noticed that my level0/level1/etc. folders are generated at `/tf/caf/configuration/<level0,...>` instead of `/tf/caf/confiuration/<org>/platform/<level0,...>`.